### PR TITLE
Modify etcd package to accept more granular configurations

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,7 @@
 etcd-cloud-operator
 Copyright 2017 Quentin Machu
 
+Modifications copyright (C) 2018 SignalFx, Inc.
+
 This product includes software developed at CoreOS, Inc.
 (http://www.coreos.com/).

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -1,5 +1,7 @@
 // Copyright 2017 Quentin Machu & eco authors
 //
+// Modifications copyright (C) 2018 SignalFx, Inc.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/etcd/misc.go
+++ b/pkg/etcd/misc.go
@@ -1,5 +1,7 @@
 // Copyright 2017 Quentin Machu & eco authors
 //
+// Modifications copyright (C) 2018 SignalFx, Inc.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -125,6 +127,9 @@ func URL2Address(pURL string) string {
 }
 
 func metricsURLs(address string) []url.URL {
+	if address == "" {
+		return []url.URL{}
+	}
 	u, _ := url.Parse(fmt.Sprintf("http://%s", address))
 	if u.Port() == "" {
 		u, _ = url.Parse(fmt.Sprintf("http://%s:%d", address, defaultMetricsPort))

--- a/pkg/etcd/misc.go
+++ b/pkg/etcd/misc.go
@@ -111,8 +111,8 @@ func peerURL(address string, tlsEnabled bool) string {
 	return url
 }
 
-func URL2Components(url string) (string, string) {
-	pURL, _ := url.Parse(url)
+func URL2Components(inURL string) (string, string) {
+	pURL, _ := url.Parse(inURL)
 	return pURL.Hostname(), pURL.Port()
 }
 

--- a/pkg/etcd/misc.go
+++ b/pkg/etcd/misc.go
@@ -95,11 +95,25 @@ func ClientsURLs(addresses []string, tlsEnabled bool) (cURLs []string) {
 }
 
 func ClientURL(address string, tlsEnabled bool) string {
-	return fmt.Sprintf("%s://%s:%d", scheme(tlsEnabled), address, defaultClientPort)
+	url := fmt.Sprintf("%s://%s", scheme(tlsEnabled), address)
+	if _, port := URL2Components(url); port == "" {
+		url = fmt.Sprintf("%s://%s:%d", scheme(tlsEnabled), address, defaultClientPort)
+	}
+	return url
+
 }
 
 func peerURL(address string, tlsEnabled bool) string {
-	return fmt.Sprintf("%s://%s:%d", scheme(tlsEnabled), address, defaultPeerPort)
+	url := fmt.Sprintf("%s://%s", scheme(tlsEnabled), address)
+	if _, port := URL2Components(url); port == "" {
+		url = fmt.Sprintf("%s://%s:%d", scheme(tlsEnabled), address, defaultPeerPort)
+	}
+	return url
+}
+
+func URL2Components(url string) (string, string) {
+	pURL, _ := url.Parse(url)
+	return pURL.Hostname(), pURL.Port()
 }
 
 func URL2Address(pURL string) string {

--- a/pkg/etcd/misc.go
+++ b/pkg/etcd/misc.go
@@ -125,7 +125,10 @@ func URL2Address(pURL string) string {
 }
 
 func metricsURLs(address string) []url.URL {
-	u, _ := url.Parse(fmt.Sprintf("http://%s:%d", address, defaultMetricsPort))
+	u, _ := url.Parse(fmt.Sprintf("http://%s", address))
+	if u.Port() == "" {
+		u, _ = url.Parse(fmt.Sprintf("http://%s:%d", address, defaultMetricsPort))
+	}
 	return []url.URL{*u}
 }
 

--- a/pkg/etcd/server.go
+++ b/pkg/etcd/server.go
@@ -1,5 +1,7 @@
 // Copyright 2017 Quentin Machu & eco authors
 //
+// Modifications copyright (C) 2018 SignalFx, Inc.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -380,7 +382,7 @@ func (c *Server) startServer(ctx context.Context) error {
 	etcdCfg.LCUrls, _ = types.NewURLs([]string{ClientURL(c.cfg.ListenOnClientAddress(), c.cfg.ClientSC.TLSEnabled())})
 	etcdCfg.ACUrls, _ = types.NewURLs([]string{ClientURL(c.cfg.AdvertisedClientAddress(), c.cfg.ClientSC.TLSEnabled())})
 	etcdCfg.ListenMetricsUrls = metricsURLs(c.cfg.MetricsAddress())
-	etcdCfg.Metrics = "extensive"
+	etcdCfg.Metrics = "basic"
 	etcdCfg.QuotaBackendBytes = c.cfg.DataQuota
 
 	// Start the server.

--- a/pkg/etcd/server.go
+++ b/pkg/etcd/server.go
@@ -67,11 +67,12 @@ type ServerConfig struct {
 	clusterState string
 	initialPURLs map[string]string
 
-	// Optional Granular Peer and Client addresses
+	// Optional Granular Peer, Client, and Metrics addresses
 	LPAddress string
 	APAddress string
 	LCAddress string
 	ACAddress string
+	MAddress string
 }
 
 func (cfg *ServerConfig) ListenOnPeerAddress() string {
@@ -100,6 +101,13 @@ func (cfg *ServerConfig) AdvertisedClientAddress() string {
 		return cfg.ACAddress
 	}
 	return cfg.PublicAddress
+}
+
+func (cfg *ServerConfig) MetricsAddress() string {
+	if cfg.MAddress != "" {
+		return cfg.MAddress
+	}
+	return cfg.PrivateAddress
 }
 
 
@@ -368,7 +376,7 @@ func (c *Server) startServer(ctx context.Context) error {
 	etcdCfg.APUrls, _ = types.NewURLs([]string{peerURL(c.cfg.AdvertisedPeerAddress(), c.cfg.PeerSC.TLSEnabled())})
 	etcdCfg.LCUrls, _ = types.NewURLs([]string{ClientURL(c.cfg.ListenOnClientAddress(), c.cfg.ClientSC.TLSEnabled())})
 	etcdCfg.ACUrls, _ = types.NewURLs([]string{ClientURL(c.cfg.AdvertisedClientAddress(), c.cfg.ClientSC.TLSEnabled())})
-	etcdCfg.ListenMetricsUrls = metricsURLs(c.cfg.PrivateAddress)
+	etcdCfg.ListenMetricsUrls = metricsURLs(c.cfg.MetricsAddress())
 	etcdCfg.Metrics = "extensive"
 	etcdCfg.QuotaBackendBytes = c.cfg.DataQuota
 

--- a/pkg/providers/snapshot/etcd/etcd.go
+++ b/pkg/providers/snapshot/etcd/etcd.go
@@ -1,5 +1,7 @@
 // Copyright 2017 Quentin Machu & eco authors
 //
+// Modifications copyright (C) 2018 SignalFx, Inc.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,7 +25,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 
 	"github.com/quentin-m/etcd-cloud-operator/pkg/providers"
 	"github.com/quentin-m/etcd-cloud-operator/pkg/providers/snapshot"
@@ -60,7 +62,7 @@ func (f *etcd) Info() (*snapshot.Metadata, error) {
 		return nil, snapshot.ErrNoSnapshot
 	}
 
-	db, err := bbolt.Open(dbPath, 0400, &bbolt.Options{ReadOnly: true})
+	db, err := bolt.Open(dbPath, 0400, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +70,7 @@ func (f *etcd) Info() (*snapshot.Metadata, error) {
 
 	var revision int64
 	var size int64
-	err = db.View(func(tx *bbolt.Tx) error {
+	err = db.View(func(tx *bolt.Tx) error {
 		size = tx.Size()
 		c := tx.Cursor()
 		for next, _ := c.First(); next != nil; next, _ = c.Next() {

--- a/pkg/providers/snapshot/etcd/etcd.go
+++ b/pkg/providers/snapshot/etcd/etcd.go
@@ -60,7 +60,7 @@ func (f *etcd) Info() (*snapshot.Metadata, error) {
 		return nil, snapshot.ErrNoSnapshot
 	}
 
-	db, err := bolt.Open(dbPath, 0400, &bolt.Options{ReadOnly: true})
+	db, err := bbolt.Open(dbPath, 0400, &bbolt.Options{ReadOnly: true})
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (f *etcd) Info() (*snapshot.Metadata, error) {
 
 	var revision int64
 	var size int64
-	err = db.View(func(tx *bolt.Tx) error {
+	err = db.View(func(tx *bbolt.Tx) error {
 		size = tx.Size()
 		c := tx.Cursor()
 		for next, _ := c.First(); next != nil; next, _ = c.Next() {


### PR DESCRIPTION
- make client and peer ports configurable
- correct bbolt package import
- make metricsURL configurable
- disable extended etcd metrics
- add locks around server.IsRunning checks