### PR TITLE
general improvements to etcd start up

### DIFF
--- a/pkg/etcd/misc.go
+++ b/pkg/etcd/misc.go
@@ -147,6 +147,17 @@ func metricsURLs(address string) []url.URL {
 	return []url.URL{*u}
 }
 
+func isEtcdMemberHealthy(address string, config SecurityConfig) bool {
+	// Determine if the member is healthy
+	cli, err := NewClient([]string{address}, config, false)
+	defer cli.Close()
+
+	if err == nil && cli.IsHealthy(5, 1*time.Second) {
+		return true
+	}
+	return false
+}
+
 func initialCluster(pURLs map[string]string) string {
 	var ic []string
 	for name, pURL := range pURLs {

--- a/pkg/etcd/misc.go
+++ b/pkg/etcd/misc.go
@@ -150,9 +150,8 @@ func metricsURLs(address string) []url.URL {
 func isEtcdMemberHealthy(address string, config SecurityConfig) bool {
 	// Determine if the member is healthy
 	cli, err := NewClient([]string{address}, config, false)
-	defer cli.Close()
-
 	if err == nil && cli.IsHealthy(5, 1*time.Second) {
+		cli.Close()
 		return true
 	}
 	return false

--- a/pkg/etcd/server.go
+++ b/pkg/etcd/server.go
@@ -133,7 +133,7 @@ func (c *Server) Seed(snapshot *snapshot.Metadata) error {
 
 	// Set the internal configuration.
 	c.cfg.clusterState = embed.ClusterStateFlagNew
-	c.cfg.initialPURLs = map[string]string{c.cfg.Name: peerURL(c.cfg.ListenOnPeerAddress(), c.cfg.PeerSC.TLSEnabled())}
+	c.cfg.initialPURLs = map[string]string{c.cfg.Name: peerURL(c.cfg.AdvertisedPeerAddress(), c.cfg.PeerSC.TLSEnabled())}
 
 	// Start the server.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultStartTimeout)
@@ -152,7 +152,7 @@ func (c *Server) Join(cluster *Client) error {
 	}
 
 	// Set the internal configuration.
-	c.cfg.initialPURLs = map[string]string{c.cfg.Name: peerURL(c.cfg.ListenOnPeerAddress(), c.cfg.PeerSC.TLSEnabled())}
+	c.cfg.initialPURLs = map[string]string{c.cfg.Name: peerURL(c.cfg.AdvertisedPeerAddress(), c.cfg.PeerSC.TLSEnabled())}
 	for _, member := range members.Members {
 		if member.Name == "" {
 			continue


### PR DESCRIPTION
* use advertised peer addresses for initial peer urls
* check for server name conflicts before joining a cluster